### PR TITLE
fix(benchmarks) Use project name instead of display name

### DIFF
--- a/modules/services/cloud-bench/task/main.tf
+++ b/modules/services/cloud-bench/task/main.tf
@@ -21,7 +21,7 @@ data "google_organization" "organization" {
 }
 
 locals {
-  benchmark_task_name   = var.is_organizational ? "Organization: ${data.google_organization.organization[0].org_id}" : data.google_project.project[0].name
+  benchmark_task_name   = var.is_organizational ? "Organization: ${data.google_organization.organization[0].org_id}" : data.google_project.project[0].id
   accounts_scope_clause = var.is_organizational ? "gcp.projectId in (\"${join("\", \"", local.project_numbers)}\")" : "gcp.projectId = \"${local.project_numbers[0]}\""
   regions_scope_clause  = length(var.regions) == 0 ? "" : " and gcp.region in (\"${join("\", \"", var.regions)}\")"
 }

--- a/modules/services/cloud-bench/trust_relationship/main.tf
+++ b/modules/services/cloud-bench/trust_relationship/main.tf
@@ -20,7 +20,7 @@ locals {
 
 resource "sysdig_secure_cloud_account" "cloud_account" {
   account_id     = data.google_project.project.number
-  alias          = data.google_project.project.name
+  alias          = data.google_project.project.id
   cloud_provider = "gcp"
   role_enabled   = "true"
   role_name      = var.role_name


### PR DESCRIPTION
We were using the display name instead of the projectID in cloud-bench, leading to errors.