### PR TITLE
chore(scan): invert default repository_project_ids

### DIFF
--- a/examples/organization/README.md
+++ b/examples/organization/README.md
@@ -46,7 +46,7 @@ module "secure-for-cloud_example_organization" {
   source = "sysdiglabs/secure-for-cloud/google//examples/organization"
 
   project_id              = "your-project-id"
-  project_scan_ids        = ["project-to-scan-1", "project-to-scan-2"]
+  repository_project_ids        = ["project-to-scan-1", "project-to-scan-2"]
   sysdig_secure_api_token = "00000000-1111-2222-3333-444444444444"
   organization_domain     = "your-domain.com"
 }
@@ -96,15 +96,16 @@ module "secure-for-cloud_example_organization" {
 |------|-------------|------|---------|:--------:|
 | <a name="input_organization_domain"></a> [organization\_domain](#input\_organization\_domain) | Organization domain. e.g. sysdig.com | `string` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Organization member project ID where the secure-for-cloud workload is going to be deployed | `string` | n/a | yes |
-| <a name="input_project_scan_ids"></a> [project\_scan\_ids](#input\_project\_scan\_ids) | Projects where a subscription must be created to pull events from their GCR topics. Warning, the topic called `gcr` must already exist in each provided project. | `list(string)` | n/a | yes |
 | <a name="input_sysdig_secure_api_token"></a> [sysdig\_secure\_api\_token](#input\_sysdig\_secure\_api\_token) | Sysdig's Secure API Token | `string` | n/a | yes |
-| <a name="input_benchmark_project_ids"></a> [benchmark\_project\_ids](#input\_benchmark\_project\_ids) | Google cloud project IDs to run Benchmarks on | `list(string)` | `[]` | no |
+| <a name="input_benchmark_project_ids"></a> [benchmark\_project\_ids](#input\_benchmark\_project\_ids) | Google cloud project IDs to run Benchmarks on. If empty, all organization projects will be defaulted. | `list(string)` | `[]` | no |
 | <a name="input_benchmark_regions"></a> [benchmark\_regions](#input\_benchmark\_regions) | List of regions in which to run the benchmark. If empty, the task will contain all regions by default. | `list(string)` | `[]` | no |
 | <a name="input_benchmark_role_name"></a> [benchmark\_role\_name](#input\_benchmark\_role\_name) | The name of the Service Account that will be created. | `string` | `"sysdigcloudbench"` | no |
+| <a name="input_create_gcr_topic"></a> [create\_gcr\_topic](#input\_create\_gcr\_topic) | Deploys a PubSub topic called `gcr` as part of this stack, which is needed for GCR scanning. Set to `true` if it doesn't exist yet. If this is not deployed, and no existing `gcr` topic is found, the GCR scanning is ommited and won't be deployed. For more info see [GCR PubSub topic](https://cloud.google.com/container-registry/docs/configuring-notifications#create_a_topic). | `bool` | `true` | no |
 | <a name="input_deploy_bench"></a> [deploy\_bench](#input\_deploy\_bench) | whether benchmark module is to be deployed | `bool` | `true` | no |
 | <a name="input_location"></a> [location](#input\_location) | Zone where the stack will be deployed | `string` | `"us-central1"` | no |
 | <a name="input_max_instances"></a> [max\_instances](#input\_max\_instances) | Max number of instances for the workloads | `number` | `1` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name to be assigned to all child resources. A suffix may be added internally when required. Use default value unless you need to install multiple instances | `string` | `"sfc"` | no |
+| <a name="input_repository_project_ids"></a> [repository\_project\_ids](#input\_repository\_project\_ids) | Projects were a `gcr`-named topic will be to subscribe to its repository events. If empty, all organization projects will be defaulted. | `list(string)` | `[]` | no |
 | <a name="input_sysdig_secure_endpoint"></a> [sysdig\_secure\_endpoint](#input\_sysdig\_secure\_endpoint) | Sysdig Secure API endpoint | `string` | `"https://secure.sysdig.com"` | no |
 
 ## Outputs

--- a/examples/organization/main.tf
+++ b/examples/organization/main.tf
@@ -123,6 +123,15 @@ module "secure_secrets" {
   name                    = var.name
 }
 
+
+#--------------------
+# scanning
+#--------------------
+locals {
+  repository_project_ids = length(var.repository_project_ids) == 0 ? [for p in data.google_projects.all_projects.projects : p.project_id] : var.repository_project_ids
+}
+
+
 module "cloud_scanning" {
   source = "../../modules/services/cloud-scanning"
 
@@ -135,15 +144,15 @@ module "cloud_scanning" {
   cloud_scanning_sa_email  = google_service_account.scanning_sa.email
   scanning_pubsub_topic_id = module.connector_organization_sink.pubsub_topic_id
   project_id               = var.project_id
-  create_gcr_topic         = false # We assume all the project_scan_ids have a topic created called gcr
-  project_scan_ids         = var.project_scan_ids
+  create_gcr_topic         = var.create_gcr_topic
+  repository_project_ids   = local.repository_project_ids
 
   max_instances = var.max_instances
 }
 
-#######################
-#      BENCHMARKS     #
-#######################
+#--------------------
+# benchmark
+#--------------------
 
 locals {
   benchmark_projects_ids = length(var.benchmark_project_ids) == 0 ? [for p in data.google_projects.all_projects.projects : p.project_id] : var.benchmark_project_ids

--- a/examples/organization/variables.tf
+++ b/examples/organization/variables.tf
@@ -14,11 +14,6 @@ variable "project_id" {
   description = "Organization member project ID where the secure-for-cloud workload is going to be deployed"
 }
 
-variable "project_scan_ids" {
-  type        = list(string)
-  description = "Projects where a subscription must be created to pull events from their GCR topics. Warning, the topic called `gcr` must already exist in each provided project."
-}
-
 # --------------------------
 # optionals, with defaults
 # --------------------------
@@ -51,6 +46,30 @@ variable "max_instances" {
   default     = 1
 }
 
+
+# scanning
+
+variable "repository_project_ids" {
+  default     = []
+  type        = list(string)
+  description = "Projects were a `gcr`-named topic will be to subscribe to its repository events. If empty, all organization projects will be defaulted."
+}
+
+variable "create_gcr_topic" {
+  type        = bool
+  description = "Deploys a PubSub topic called `gcr` as part of this stack, which is needed for GCR scanning. Set to `true` if it doesn't exist yet. If this is not deployed, and no existing `gcr` topic is found, the GCR scanning is ommited and won't be deployed. For more info see [GCR PubSub topic](https://cloud.google.com/container-registry/docs/configuring-notifications#create_a_topic)."
+  default     = true
+}
+
+
+# benchmark
+
+variable "deploy_bench" {
+  type        = bool
+  description = "whether benchmark module is to be deployed"
+  default     = true
+}
+
 variable "benchmark_regions" {
   type        = list(string)
   description = "List of regions in which to run the benchmark. If empty, the task will contain all regions by default."
@@ -60,17 +79,11 @@ variable "benchmark_regions" {
 variable "benchmark_project_ids" {
   default     = []
   type        = list(string)
-  description = "Google cloud project IDs to run Benchmarks on"
+  description = "Google cloud project IDs to run Benchmarks on. If empty, all organization projects will be defaulted."
 }
 
 variable "benchmark_role_name" {
   type        = string
   description = "The name of the Service Account that will be created."
   default     = "sysdigcloudbench"
-}
-
-variable "deploy_bench" {
-  type        = bool
-  description = "whether benchmark module is to be deployed"
-  default     = true
 }

--- a/examples/single-project/main.tf
+++ b/examples/single-project/main.tf
@@ -87,7 +87,7 @@ module "cloud_scanning" {
   scanning_pubsub_topic_id = module.scanning_project_sink.pubsub_topic_id
   create_gcr_topic         = var.create_gcr_topic
   project_id               = var.project_id
-  project_scan_ids         = [var.project_id]
+  repository_project_ids   = [var.project_id]
 
   secure_api_token_secret_id = module.secure_secrets.secure_api_token_secret_name
   sysdig_secure_api_token    = var.sysdig_secure_api_token

--- a/modules/services/cloud-bench/README.md
+++ b/modules/services/cloud-bench/README.md
@@ -43,7 +43,7 @@ No resources.
 | <a name="input_is_organizational"></a> [is\_organizational](#input\_is\_organizational) | Whether this task is being created at the org or project level | `bool` | `false` | no |
 | <a name="input_organization_domain"></a> [organization\_domain](#input\_organization\_domain) | Organization domain. e.g. sysdig.com | `string` | `""` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | ID of project to run the benchmark on | `string` | `""` | no |
-| <a name="input_project_ids"></a> [project\_ids](#input\_project\_ids) | IDs of projects to run the benchmark on | `list(string)` | `[]` | no |
+| <a name="input_project_ids"></a> [project\_ids](#input\_project\_ids) | IDs of projects to run the benchmark on. If empty, all organization projects will be defaulted. | `list(string)` | `[]` | no |
 | <a name="input_regions"></a> [regions](#input\_regions) | List of regions in which to run the benchmark. If empty, the task will contain all regions by default. | `list(string)` | `[]` | no |
 | <a name="input_role_name"></a> [role\_name](#input\_role\_name) | The name of the Service Account that will be created. | `string` | `"sysdigcloudbench"` | no |
 

--- a/modules/services/cloud-bench/variables.tf
+++ b/modules/services/cloud-bench/variables.tf
@@ -20,7 +20,7 @@ variable "project_id" {
 # For organizational
 variable "project_ids" {
   type        = list(string)
-  description = "IDs of projects to run the benchmark on"
+  description = "IDs of projects to run the benchmark on. If empty, all organization projects will be defaulted."
   default     = []
 }
 

--- a/modules/services/cloud-scanning/README.md
+++ b/modules/services/cloud-scanning/README.md
@@ -11,7 +11,7 @@ module "cloud_scanning_gcp" {
 
   sysdig_secure_api_token = "00000000-1111-2222-3333-444444444444"
   sysdig_secure_endpoint  = "https://secure.sysdig.com"
-  project_scan_ids        = ["project-id-to-scan"]
+  repository_project_ids        = ["project-id-to-scan"]
 
   # Set to "false" if there's an existing PubSub topic called "gcr"
   create_gcr_topic = true
@@ -56,18 +56,18 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_cloud_scanning_sa_email"></a> [cloud\_scanning\_sa\_email](#input\_cloud\_scanning\_sa\_email) | Cloud Connector service account email | `string` | n/a | yes |
-| <a name="input_create_gcr_topic"></a> [create\_gcr\_topic](#input\_create\_gcr\_topic) | Deploys a PubSub topic called `gcr` as part of this stack, which is needed for GCR scanning. Set to `true` only if it doesn't exist yet. If this is not deployed, and no existing `gcr` topic is found, the GCR scanning is ommited and won't be deployed. For more info see [GCR PubSub topic](https://cloud.google.com/container-registry/docs/configuring-notifications#create_a_topic). | `bool` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | organizational member project ID where the secure-for-cloud workload is going to be deployed | `string` | n/a | yes |
 | <a name="input_scanning_pubsub_topic_id"></a> [scanning\_pubsub\_topic\_id](#input\_scanning\_pubsub\_topic\_id) | Cloud Scanning PubSub single account topic id | `string` | n/a | yes |
 | <a name="input_secure_api_token_secret_id"></a> [secure\_api\_token\_secret\_id](#input\_secure\_api\_token\_secret\_id) | Sysdig Secure API token secret id | `string` | n/a | yes |
 | <a name="input_sysdig_secure_api_token"></a> [sysdig\_secure\_api\_token](#input\_sysdig\_secure\_api\_token) | Sysdig's Secure API Token | `string` | n/a | yes |
 | <a name="input_sysdig_secure_endpoint"></a> [sysdig\_secure\_endpoint](#input\_sysdig\_secure\_endpoint) | Sysdig's Secure API URL | `string` | n/a | yes |
+| <a name="input_create_gcr_topic"></a> [create\_gcr\_topic](#input\_create\_gcr\_topic) | true / false whether a `gcr`-named pubsub topic will be created. Needed for GCR scanning. If this topic does not exist nor is created,  the GCR scanning is ommited and won't be deployed. For more info see [GCR PubSub topic](https://cloud.google.com/container-registry/docs/configuring-notifications#create_a_topic). | `bool` | `true` | no |
 | <a name="input_extra_envs"></a> [extra\_envs](#input\_extra\_envs) | Extra environment variables for the Cloud Scanning instance | `map(string)` | `{}` | no |
 | <a name="input_image_name"></a> [image\_name](#input\_image\_name) | Cloud scanning image to deploy | `string` | `"gcr.io/mateo-burillo-ns/cloud-scanning:latest"` | no |
 | <a name="input_location"></a> [location](#input\_location) | Zone where the cloud scanning will be deployed | `string` | `"us-central1"` | no |
 | <a name="input_max_instances"></a> [max\_instances](#input\_max\_instances) | Max number of instances for the Cloud Scanning | `number` | `1` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name to be assigned to all child resources. A suffix may be added internally when required. Use default value unless you need to install multiple instances | `string` | `"sfc-cloudscanning"` | no |
-| <a name="input_project_scan_ids"></a> [project\_scan\_ids](#input\_project\_scan\_ids) | Projects where a subscription must be created to pull events from their GCR topics to scan their images. Warning, a topic called `gcr` must already exist in each provided project. | `list(string)` | `[]` | no |
+| <a name="input_repository_project_ids"></a> [repository\_project\_ids](#input\_repository\_project\_ids) | Projects were a `gcr`-named topic will be to subscribe to its repository events. If empty, all organization projects will be defaulted. | `list(string)` | `[]` | no |
 | <a name="input_verify_ssl"></a> [verify\_ssl](#input\_verify\_ssl) | Verify the SSL certificate of the Secure endpoint | `bool` | `true` | no |
 
 ## Outputs

--- a/modules/services/cloud-scanning/variables.tf
+++ b/modules/services/cloud-scanning/variables.tf
@@ -4,11 +4,6 @@ variable "cloud_scanning_sa_email" {
   description = "Cloud Connector service account email"
 }
 
-variable "create_gcr_topic" {
-  type        = bool
-  description = "Deploys a PubSub topic called `gcr` as part of this stack, which is needed for GCR scanning. Set to `true` only if it doesn't exist yet. If this is not deployed, and no existing `gcr` topic is found, the GCR scanning is ommited and won't be deployed. For more info see [GCR PubSub topic](https://cloud.google.com/container-registry/docs/configuring-notifications#create_a_topic)."
-}
-
 variable "secure_api_token_secret_id" {
   type        = string
   description = "Sysdig Secure API token secret id"
@@ -39,6 +34,21 @@ variable "project_id" {
 # --------------------------
 # optionals, with defaults
 # --------------------------
+
+variable "create_gcr_topic" {
+  type        = bool
+  description = "true / false whether a `gcr`-named pubsub topic will be created. Needed for GCR scanning. If this topic does not exist nor is created,  the GCR scanning is ommited and won't be deployed. For more info see [GCR PubSub topic](https://cloud.google.com/container-registry/docs/configuring-notifications#create_a_topic)."
+  default     = true
+}
+
+
+variable "repository_project_ids" {
+  type        = list(string)
+  description = "Projects were a `gcr`-named topic will be to subscribe to its repository events. If empty, all organization projects will be defaulted."
+  default     = []
+}
+
+
 
 variable "verify_ssl" {
   type        = bool
@@ -74,10 +84,4 @@ variable "max_instances" {
   type        = number
   description = "Max number of instances for the Cloud Scanning"
   default     = 1
-}
-
-variable "project_scan_ids" {
-  type        = list(string)
-  description = "Projects where a subscription must be created to pull events from their GCR topics to scan their images. Warning, a topic called `gcr` must already exist in each provided project."
-  default     = []
 }

--- a/test/fixtures/organization/main.tf
+++ b/test/fixtures/organization/main.tf
@@ -4,18 +4,15 @@ resource "random_string" "random" {
   upper   = false
 }
 
-resource "google_pubsub_topic" "gcr" {
-  project = var.project_id
-  name    = "gcr"
-}
-
 module "sfc_example_organization" {
   source = "../../../examples/organization"
 
-  organization_domain     = var.organization_domain
   sysdig_secure_api_token = var.sysdig_secure_api_token
-  name                    = "sfc${random_string.random.result}"
-  project_id              = var.project_id
-  project_scan_ids        = [var.project_id]
-  deploy_bench            = false
+  sysdig_secure_endpoint  = var.sysdig_secure_endpoint
+
+  organization_domain    = var.organization_domain
+  name                   = "sfc${random_string.random.result}"
+  project_id             = var.project_id
+  repository_project_ids = [var.project_id]
+  deploy_bench           = false
 }

--- a/test/fixtures/organization/variables.tf
+++ b/test/fixtures/organization/variables.tf
@@ -1,3 +1,9 @@
+variable "sysdig_secure_endpoint" {
+  type        = string
+  default     = "https://secure.sysdig.com"
+  description = "Sysdig Secure API endpoint"
+}
+
 variable "sysdig_secure_api_token" {
   type        = string
   description = "Sysdig secure api token"

--- a/test/fixtures/single-project/main.tf
+++ b/test/fixtures/single-project/main.tf
@@ -8,8 +8,8 @@ module "sfc_example_single_project" {
   source = "../../../examples/single-project"
 
   sysdig_secure_api_token = var.sysdig_secure_api_token
+  sysdig_secure_endpoint  = var.sysdig_secure_endpoint
   name                    = "sfc${random_string.random.result}"
-  create_gcr_topic        = true
   project_id              = var.project_id
   deploy_bench            = false
 }

--- a/test/fixtures/single-project/variables.tf
+++ b/test/fixtures/single-project/variables.tf
@@ -4,6 +4,12 @@ variable "sysdig_secure_api_token" {
   sensitive   = true
 }
 
+variable "sysdig_secure_endpoint" {
+  type        = string
+  default     = "https://secure.sysdig.com"
+  description = "Sysdig Secure API endpoint"
+}
+
 variable "project_id" {
   type        = string
   description = "Project ID where the secure-for-cloud workload is going to be deployed"


### PR DESCRIPTION
- [X] give a better name to `project_scan_ids` > `repository_project_ids`
- [X] organizational, make `create_gcr_topic` work
- [X] organizational,  ⬆️ use `repository_project_ids` for subscription, and also for topic creation if flag is to true
- [x] enhance some descriptions