### PR TITLE
feat: Allow multiple pubsub_push_http_subscription deployments

### DIFF
--- a/modules/infrastructure/pubsub_push_http_subscription/main.tf
+++ b/modules/infrastructure/pubsub_push_http_subscription/main.tf
@@ -4,7 +4,7 @@ data "google_pubsub_topic" "topic" {
 }
 
 locals {
-  create_topic = (data.google_pubsub_topic.topic.name == null || lookup(coalesce(data.google_pubsub_topic.topic.labels, {}), "sysdig-managed", "false") == "true")
+  create_topic = (data.google_pubsub_topic.topic.name == null || lookup(coalesce(data.google_pubsub_topic.topic.labels, {}), "sysdig-managed", "NOT_A_VALUE") == var.name)
 }
 
 resource "google_pubsub_topic" "topic" {
@@ -12,7 +12,7 @@ resource "google_pubsub_topic" "topic" {
   name    = var.topic_name
   project = var.topic_project_id
   labels = {
-    sysdig-managed = "true"
+    sysdig-managed = var.name
   }
 }
 


### PR DESCRIPTION
Allows multiple deployments without colliding the GCR topic creations through name.

Currently, when creating multiple deployments using this module, it still crashes with an `already exists` error, if the name of the topic is the same. This changes the label value to match, so multiple deployments won't try to re-create the same topic, but reuse it instead.