### PR TITLE
Update Service Account Roles

### DIFF
--- a/modules/services/cloud-bench/trust_relationship/main.tf
+++ b/modules/services/cloud-bench/trust_relationship/main.tf
@@ -40,11 +40,27 @@ resource "google_service_account" "sa" {
   display_name = "Service account for cloud-bench"
 }
 
-resource "google_project_iam_member" "security_viewer" {
+resource "google_project_iam_member" "viewer" {
   project = var.project_id
 
-  role   = "roles/iam.securityReviewer"
+  role   = "roles/viewer"
   member = "serviceAccount:${google_service_account.sa.email}"
+}
+
+resource "google_project_iam_member" "custom" {
+  project = var.project_id
+
+  role   = google_project_iam_custom_role.custom.id
+  member = "serviceAccount:${google_service_account.sa.email}"
+}
+
+resource "google_project_iam_custom_role" "custom" {
+  project = var.project_id
+
+  role_id     = var.role_name
+  title       = "Sysdig Cloud Benchmark Role"
+  description = "A Role providing the required permissions for Sysdig Cloud Benchmarks that are not included in roles/viewer"
+  permissions = ["storage.buckets.getIamPolicy", "bigquery.tables.list"]
 }
 
 resource "google_service_account_iam_binding" "sa_pool_binding" {

--- a/modules/services/cloud-bench/trust_relationship/main.tf
+++ b/modules/services/cloud-bench/trust_relationship/main.tf
@@ -40,27 +40,11 @@ resource "google_service_account" "sa" {
   display_name = "Service account for cloud-bench"
 }
 
-resource "google_project_iam_member" "viewer" {
+resource "google_project_iam_member" "security_viewer" {
   project = var.project_id
 
-  role   = "roles/viewer"
+  role   = "roles/iam.securityReviewer"
   member = "serviceAccount:${google_service_account.sa.email}"
-}
-
-resource "google_project_iam_member" "custom" {
-  project = var.project_id
-
-  role   = google_project_iam_custom_role.custom.id
-  member = "serviceAccount:${google_service_account.sa.email}"
-}
-
-resource "google_project_iam_custom_role" "custom" {
-  project = var.project_id
-
-  role_id     = var.role_name
-  title       = "Sysdig Cloud Benchmark Role"
-  description = "A Role providing the required permissions for Sysdig Cloud Benchmarks that are not included in roles/viewer"
-  permissions = ["storage.buckets.getIamPolicy"]
 }
 
 resource "google_service_account_iam_binding" "sa_pool_binding" {

--- a/modules/services/cloud-connector/README.md
+++ b/modules/services/cloud-connector/README.md
@@ -22,14 +22,14 @@ module "cloud_connector_gcp" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.67.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 3.67.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.1.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | >= 3.67.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 3.67.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.1.0 |
 
 ## Modules

--- a/modules/services/cloud-connector/versions.tf
+++ b/modules/services/cloud-connector/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.67.0"
+      version = "~> 3.67.0"
     }
     random = {
       version = ">= 3.1.0"

--- a/modules/services/cloud-scanning/README.md
+++ b/modules/services/cloud-scanning/README.md
@@ -24,13 +24,13 @@ module "cloud_scanning_gcp" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.67.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 3.67.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | >= 3.67.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 3.67.0 |
 
 ## Modules
 

--- a/modules/services/cloud-scanning/versions.tf
+++ b/modules/services/cloud-scanning/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.67.0"
+      version = "~> 3.67.0"
     }
   }
 }


### PR DESCRIPTION
The service account running GCP benchmarks requires `bigquery.tables.list`