### PR TITLE
fix: Add missing permission to single-project deployments

### DIFF
--- a/modules/services/cloud-connector/README.md
+++ b/modules/services/cloud-connector/README.md
@@ -25,14 +25,14 @@ module "cloud_connector_gcp" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 3.67.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.67.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.1.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | ~> 3.67.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 3.67.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.1.0 |
 
 ## Modules
@@ -48,6 +48,7 @@ No modules.
 | [google_eventarc_trigger.trigger](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/eventarc_trigger) | resource |
 | [google_project_iam_member.builder](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.event_receiver](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.run_viewer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.service_account_user_itself](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.token_creator](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_storage_bucket.bucket](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket) | resource |

--- a/modules/services/cloud-connector/cloud_run.tf
+++ b/modules/services/cloud-connector/cloud_run.tf
@@ -122,3 +122,8 @@ resource "google_cloud_run_service_iam_member" "run_invoker" {
   project  = google_cloud_run_service.cloud_connector.project
   location = google_cloud_run_service.cloud_connector.location
 }
+
+resource "google_project_iam_member" "run_viewer" {
+  member = "serviceAccount:${var.cloud_connector_sa_email}"
+  role   = "roles/run.viewer"
+}

--- a/modules/services/cloud-connector/versions.tf
+++ b/modules/services/cloud-connector/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.67.0"
+      version = ">= 3.67.0"
     }
     random = {
       version = ">= 3.1.0"

--- a/modules/services/cloud-scanning/README.md
+++ b/modules/services/cloud-scanning/README.md
@@ -23,13 +23,13 @@ module "cloud_scanning_gcp" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 3.67.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.67.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | ~> 3.67.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 3.67.0 |
 
 ## Modules
 

--- a/modules/services/cloud-scanning/versions.tf
+++ b/modules/services/cloud-scanning/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.67.0"
+      version = ">= 3.67.0"
     }
   }
 }


### PR DESCRIPTION
<!--
check contribution guidelines at https://github.com/sysdiglabs/terraform-google-secure-for-cloud/blob/master/CONTRIBUTE.md#contribution-checklist
-->
Adds a missing permission for the Service Account to retrieve the Cloud Run details for single-project deployments.