### PR TITLE
docs: remove CIEM capability from gcp

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -3,6 +3,7 @@ driver:
   name: terraform
   root_module_directory: test/fixtures
   parallelism: 4
+  verify_version: false
 
 provisioner:
   name: terraform

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ Provides unified threat-detection, compliance, forensics and analysis through th
 
 * **[CSPM/Compliance](https://docs.sysdig.com/en/docs/sysdig-secure/benchmarks/)**: It evaluates periodically your cloud configuration, using Cloud Custodian, against some benchmarks and returns the results and remediation you need to fix. Managed through `cloud-bench` module. <br/>
 
-* **[CIEM](https://docs.sysdig.com/en/docs/sysdig-secure/posture/)**: Permissions and Entitlements management. Requires BOTH modules  `cloud-connector` and `cloud-bench`. <br/>
-
 * **[Cloud Threat Detection](https://docs.sysdig.com/en/docs/sysdig-secure/insights/)**: Tracks abnormal and suspicious activities in your cloud environment based on Falco language. Managed through `cloud-connector` module. <br/>
 
 * **[Cloud Scanning](https://docs.sysdig.com/en/docs/sysdig-secure/scanning/)**: Automatically scans all container images pushed to the registry or as soon a new task which involves a container is spawned in your account. Managed through `cloud-connector`. <br/>


### PR DESCRIPTION
only available in aws

<!--
check contribution guidelines at https://github.com/sysdiglabs/terraform-google-secure-for-cloud/blob/master/CONTRIBUTE.md#contribution-checklist
-->
