### PR TITLE
fix(bench) Use projectID instead of project name

### DIFF
--- a/modules/services/cloud-bench/trust_relationship/main.tf
+++ b/modules/services/cloud-bench/trust_relationship/main.tf
@@ -20,13 +20,10 @@ locals {
 
 resource "sysdig_secure_cloud_account" "cloud_account" {
   account_id     = data.google_project.project.number
+  alias          = data.google_project.project.project_id
   cloud_provider = "gcp"
   role_enabled   = "true"
   role_name      = var.role_name
-
-  # Required as datasource prefixes id with '/projects/':
-  # https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_project#id
-  alias = trimprefix(data.google_project.project.id, "projects/")
 }
 
 ###################################################


### PR DESCRIPTION
Cloud bench was creating cloud accounts in the backend storing the project name instead of the project id. In most cases this is fine, however if the project name contains capital letters, the project id defaults to the lowercased version of the name.

For customers with capital letters in their project names, this was leading to errors like: 

```
googleapiclient.errors.HttpError: <HttpError 400 when requesting 
https://bigquery.googleapis.com/bigquery/v2/projects/ConfidentialNode/datasets?alt=json returned "Invalid project ID 
'ConfidentialNode'. Project IDs must contain 6-63 lowercase letters, digits, or dashes. Some project IDs also include 
domain name separated by a colon. IDs must start with a letter and may not end with a dash.">```