### PR TITLE
fix(single-project-k8s) Add missing providers to k8s example

### DIFF
--- a/examples/single-project-k8s/README.md
+++ b/examples/single-project-k8s/README.md
@@ -68,8 +68,8 @@ Notice that:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | ~> 3.67.0 |
-| <a name="provider_helm"></a> [helm](#provider\_helm) | >=2.3.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 3.67.0 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.4.1 |
 
 ## Modules
 

--- a/examples/single-project-k8s/README.md
+++ b/examples/single-project-k8s/README.md
@@ -30,6 +30,11 @@ provider "google" {
   region  = "<REGION_ID>; ex. us-central-1"
 }
 
+provider "google-beta" {
+  project = "<PROJECT_ID>"
+  region  = "<REGION_ID>; ex. us-central-1"
+}
+
 provider "helm" {
   kubernetes {
     config_path = "~/.kube/config"
@@ -57,14 +62,14 @@ Notice that:
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | ~> 3.67.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >=2.3.0 |
-| <a name="requirement_sysdig"></a> [sysdig](#requirement\_sysdig) | >= 0.5.19 |
+| <a name="requirement_sysdig"></a> [sysdig](#requirement\_sysdig) | >= 0.5.21 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 3.67.0 |
-| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.4.1 |
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 3.67.0 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | >=2.3.0 |
 
 ## Modules
 

--- a/examples/single-project-k8s/benchmark.tf
+++ b/examples/single-project-k8s/benchmark.tf
@@ -1,3 +1,9 @@
+provider "sysdig" {
+  sysdig_secure_url          = var.sysdig_secure_endpoint
+  sysdig_secure_api_token    = var.sysdig_secure_api_token
+  sysdig_secure_insecure_tls = !local.verify_ssl
+}
+
 module "cloud_bench" {
   count  = var.deploy_benchmark ? 1 : 0
   source = "../../modules/services/cloud-bench"

--- a/examples/single-project-k8s/versions.tf
+++ b/examples/single-project-k8s/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     sysdig = {
       source  = "sysdiglabs/sysdig"
-      version = ">= 0.5.19"
+      version = ">= 0.5.21"
     }
     helm = {
       source  = "hashicorp/helm"


### PR DESCRIPTION
The single-project-k8s example is missing the `sysdig` and `google-beta` providers, causing the module to fail. 