### PR TITLE
chore: add issue opened slack notification action

### DIFF
--- a/.github/workflows/issues-slack-notify.yml
+++ b/.github/workflows/issues-slack-notify.yml
@@ -1,0 +1,19 @@
+on:
+  issues:
+    types: [opened]
+name: Issue created Slack Notification
+jobs:
+  slackNotification:
+    name: Slack Notification
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: ws-cloudnative-internal
+          SLACK_ICON: https://github.com/fluidicon.png
+          SLACK_MESSAGE: 'An issue has been opened in Google Terraform repository'
+          SLACK_TITLE: Issue Created
+          SLACK_USERNAME: gitHub
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/modules/services/cloud-connector/README.md
+++ b/modules/services/cloud-connector/README.md
@@ -33,7 +33,7 @@ module "cloud_connector_gcp" {
 | Name | Version |
 |------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | 3.67.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.1.2 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.1.3 |
 
 ## Modules
 


### PR DESCRIPTION
Add an action to notify slack when an issue is opened
<!--
check contribution guidelines at https://github.com/sysdiglabs/terraform-google-secure-for-cloud/blob/master/CONTRIBUTE.md#contribution-checklist
-->
