### PR TITLE
feat: pin down secure-api-secret location from global to specific

### DIFF
--- a/examples/organization/README.md
+++ b/examples/organization/README.md
@@ -106,8 +106,8 @@ module "secure-for-cloud_example_organization" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 4.33.0 |
-| <a name="provider_sysdig"></a> [sysdig](#provider\_sysdig) | 0.5.39 |
+| <a name="provider_google"></a> [google](#provider\_google) | 4.34.0 |
+| <a name="provider_sysdig"></a> [sysdig](#provider\_sysdig) | 0.5.40 |
 
 ## Modules
 

--- a/examples/single-project-k8s/README.md
+++ b/examples/single-project-k8s/README.md
@@ -81,9 +81,9 @@ See [inputs summary](#inputs) or module module [`variables.tf`](./variables.tf) 
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 4.33.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 4.34.0 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | 2.6.0 |
-| <a name="provider_sysdig"></a> [sysdig](#provider\_sysdig) | 0.5.39 |
+| <a name="provider_sysdig"></a> [sysdig](#provider\_sysdig) | 0.5.40 |
 
 ## Modules
 

--- a/examples/single-project/README.md
+++ b/examples/single-project/README.md
@@ -82,8 +82,8 @@ module "secure-for-cloud_example_single-project" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 4.33.0 |
-| <a name="provider_sysdig"></a> [sysdig](#provider\_sysdig) | 0.5.39 |
+| <a name="provider_google"></a> [google](#provider\_google) | 4.34.0 |
+| <a name="provider_sysdig"></a> [sysdig](#provider\_sysdig) | 0.5.40 |
 
 ## Modules
 

--- a/examples/trigger-events/README.md
+++ b/examples/trigger-events/README.md
@@ -38,7 +38,7 @@ module "secure-for-cloud_trigger_events" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 4.33.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 4.34.0 |
 
 ## Modules
 

--- a/modules/infrastructure/organization_sink/README.md
+++ b/modules/infrastructure/organization_sink/README.md
@@ -12,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 4.33.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 4.34.0 |
 
 ## Modules
 

--- a/modules/infrastructure/project_sink/README.md
+++ b/modules/infrastructure/project_sink/README.md
@@ -12,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 4.33.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 4.34.0 |
 
 ## Modules
 

--- a/modules/infrastructure/pubsub_subscription/README.md
+++ b/modules/infrastructure/pubsub_subscription/README.md
@@ -15,7 +15,7 @@ already exists in the project. It will create the topic if it doesn't exist.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 4.33.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 4.34.0 |
 
 ## Modules
 

--- a/modules/infrastructure/secrets/README.md
+++ b/modules/infrastructure/secrets/README.md
@@ -12,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 4.33.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 4.34.0 |
 
 ## Modules
 
@@ -25,6 +25,7 @@ No modules.
 | [google_secret_manager_secret.secure_api_secret](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret) | resource |
 | [google_secret_manager_secret_iam_member.secret_reader](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
 | [google_secret_manager_secret_version.secure_api_secret](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_version) | resource |
+| [google_client_config.current](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/client_config) | data source |
 
 ## Inputs
 

--- a/modules/infrastructure/secrets/data.tf
+++ b/modules/infrastructure/secrets/data.tf
@@ -1,0 +1,2 @@
+data "google_client_config" "current" {
+}

--- a/modules/infrastructure/secrets/main.tf
+++ b/modules/infrastructure/secrets/main.tf
@@ -1,7 +1,11 @@
 resource "google_secret_manager_secret" "secure_api_secret" {
   secret_id = "${var.name}-sysdig-secure-api-secret"
   replication {
-    automatic = true
+    user_managed {
+      replicas {
+        location = data.google_client_config.current.region
+      }
+    }
   }
 }
 

--- a/modules/services/cloud-connector/README.md
+++ b/modules/services/cloud-connector/README.md
@@ -32,7 +32,7 @@ module "cloud_connector_gcp" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 4.33.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 4.34.0 |
 
 ## Modules
 


### PR DESCRIPTION
Update the module to create secret in location specified in google provider configuration instead of global.