### PR TITLE
fix: terrascan compliance

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -60,6 +60,7 @@ jobs:
         run: |
           pip install pre-commit
           go install github.com/hashicorp/terraform-config-inspect@latest
+          make deps
       - name: Initialize terraform modules
         if: ${{ matrix.directory !=  '.' }}
         run: |

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -113,9 +113,7 @@ jobs:
       - name: Install pre-commit dependencies
         run: |
           pip install pre-commit
-          go install github.com/terraform-docs/terraform-docs@v0.16.0
-          go install github.com/hashicorp/terraform-config-inspect@latest
-          curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
+          make deps
       - name: Execute pre-commit
         # Run all pre-commit checks on max version supported
         if: ${{ matrix.version ==  needs.getBaseVersion.outputs.maxVersion }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,7 @@ repos:
           - '--args=--only=terraform_required_providers'
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
+      - id: terrascan
   - repo: local
     hooks:
       - id: terraform_init

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,11 @@ deps:
 		unzip tflint.zip && \
 		rm tflint.zip && \
 		mv tflint "`go env GOPATH`/bin"
+	curl -L "`curl -s https://api.github.com/repos/tenable/terrascan/releases/latest | grep -o -E "https://.+?_Linux_x86_64.tar.gz"`" -o terrascan.tar.gz && \
+		tar -xf terrascan.tar.gz terrascan && \
+		rm terrascan.tar.gz && \
+		install terrascan "`go env GOPATH`/bin" && \
+		rm terrascan
 
 clean:
 	find -name ".terraform" -type d | xargs rm -rf

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ deps:
 		unzip tflint.zip && \
 		rm tflint.zip && \
 		mv tflint "`go env GOPATH`/bin"
-	curl -L "`curl -s https://api.github.com/repos/tenable/terrascan/releases/latest | grep -o -E "https://.+?_Linux_x86_64.tar.gz"`" -o terrascan.tar.gz && \
+	curl -L https://github.com/tenable/terrascan/releases/download/v1.9.0/terrascan_1.9.0_Linux_x86_64.tar.gz -o terrascan.tar.gz && \
 		tar -xf terrascan.tar.gz terrascan && \
 		rm terrascan.tar.gz && \
 		install terrascan "`go env GOPATH`/bin" && \

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ $ terraform import 'module.secure-for-cloud_example_single-project.module.cloud_
 $ terraform import 'module.secure-for-cloud_example_organization.module.cloud_bench[0].module.trust_relationship["<YOUR_PROJECT_ID>"].google_iam_workload_identity_pool.pool' sysdigcloud
 $ terraform import 'module.secure-for-cloud_example_organization.module.cloud_bench[0].module.trust_relationship["<YOUR_PROJECT_ID>"].google_iam_workload_identity_pool_provider.pool_provider' sysdigcloud/sysdigcloud
  ```
- 
+
  Note: if you're using terragrunt, run `terragrunt import`
 
 ### Q: Getting "Error creating Topic: googleapi: Error 409: Resource already exists in the project (resource=gcr)"

--- a/examples/single-project-k8s/credentials.tf
+++ b/examples/single-project-k8s/credentials.tf
@@ -14,6 +14,10 @@ resource "google_project_iam_member" "event_receiver" {
 }
 
 resource "google_project_iam_member" "token_creator" {
+  # Why: Image scanning is run from inside a container. As it needs to get the image from the registry it needs a token to get it from the registry.
+  # How to avoid security issues: As in the next implementation scanning will be run from within cloudrun which has needed permissions and won't need a token.
+  # Warning: Organization users musn't be able to impersonate as the created service account.
+  #ts:skip=AC_GCP_0006
   project = data.google_client_config.current.project
   member  = "serviceAccount:${google_service_account.connector_sa.email}"
   role    = "roles/iam.serviceAccountTokenCreator"

--- a/examples/single-project-k8s/credentials.tf
+++ b/examples/single-project-k8s/credentials.tf
@@ -14,10 +14,11 @@ resource "google_project_iam_member" "event_receiver" {
 }
 
 resource "google_project_iam_member" "token_creator" {
+  # AC_GCP_0006
   # Why: Image scanning is run from inside a container. As it needs to get the image from the registry it needs a token to get it from the registry.
   # How to avoid security issues: As in the next implementation scanning will be run from within cloudrun which has needed permissions and won't need a token.
   # Warning: Organization users musn't be able to impersonate as the created service account.
-  #ts:skip=AC_GCP_0006
+  #ts:skip=AC_GCP_0006 Image scanning is run from inside a container. As it needs to get the image from the registry it needs a token to get it from the registry.
   project = data.google_client_config.current.project
   member  = "serviceAccount:${google_service_account.connector_sa.email}"
   role    = "roles/iam.serviceAccountTokenCreator"

--- a/modules/infrastructure/cloud_build_permission/main.tf
+++ b/modules/infrastructure/cloud_build_permission/main.tf
@@ -1,5 +1,9 @@
 # Required to execute cloud build runs with this same service account
 resource "google_project_iam_member" "service_account_user_itself" {
+  # Why: Image scanning is run from inside a container. As it needs to get the image from the registry it needs a token to get it from the registry.
+  # How to avoid security issues: As in the next implementation scanning will be run from within cloudrun which has needed permissions and won't need a token.
+  # Warning: Organization users musn't be able to impersonate as the created service account.
+  #ts:skip=AC_GCP_0006
   project = var.project_id
   role    = "roles/iam.serviceAccountUser"
   member  = "serviceAccount:${var.cloud_connector_sa_email}"

--- a/modules/infrastructure/cloud_build_permission/main.tf
+++ b/modules/infrastructure/cloud_build_permission/main.tf
@@ -1,9 +1,10 @@
 # Required to execute cloud build runs with this same service account
 resource "google_project_iam_member" "service_account_user_itself" {
+  # AC_GCP_0006
   # Why: Image scanning is run from inside a container. As it needs to get the image from the registry it needs a token to get it from the registry.
   # How to avoid security issues: As in the next implementation scanning will be run from within cloudrun which has needed permissions and won't need a token.
   # Warning: Organization users musn't be able to impersonate as the created service account.
-  #ts:skip=AC_GCP_0006
+  #ts:skip=AC_GCP_0006 Image scanning is run from inside a container. As it needs to get the image from the registry it needs a token to get it from the registry.
   project = var.project_id
   role    = "roles/iam.serviceAccountUser"
   member  = "serviceAccount:${var.cloud_connector_sa_email}"

--- a/modules/services/cloud-connector/pubsub_permissions.tf
+++ b/modules/services/cloud-connector/pubsub_permissions.tf
@@ -5,10 +5,11 @@ resource "google_project_iam_member" "event_receiver" {
 }
 
 resource "google_project_iam_member" "token_creator" {
+  # AC_GCP_0006
   # Why: Image scanning is run from inside a container. As it needs to get the image from the registry it needs a token to get it from the registry.
   # How to avoid security issues: As in the next implementation scanning will be run from within cloudrun which has needed permissions and won't need a token.
   # Warning: Organization users musn't be able to impersonate as the created service account.
-  #ts:skip=AC_GCP_0006
+  #ts:skip=AC_GCP_0006 Image scanning is run from inside a container. As it needs to get the image from the registry it needs a token to get it from the registry.
   project = var.project_id
   member  = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
   role    = "roles/iam.serviceAccountTokenCreator"

--- a/modules/services/cloud-connector/pubsub_permissions.tf
+++ b/modules/services/cloud-connector/pubsub_permissions.tf
@@ -5,6 +5,10 @@ resource "google_project_iam_member" "event_receiver" {
 }
 
 resource "google_project_iam_member" "token_creator" {
+  # Why: Image scanning is run from inside a container. As it needs to get the image from the registry it needs a token to get it from the registry.
+  # How to avoid security issues: As in the next implementation scanning will be run from within cloudrun which has needed permissions and won't need a token.
+  # Warning: Organization users musn't be able to impersonate as the created service account.
+  #ts:skip=AC_GCP_0006
   project = var.project_id
   member  = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
   role    = "roles/iam.serviceAccountTokenCreator"


### PR DESCRIPTION
Why: Image scanning is run from inside a container. As it needs to get the image from the registry it needs a token to get it from the registry.
How to avoid security issues: As in the next implementation scanning will be run from within cloudrun which has needed permissions and won't need a token.
Warning: Organization users musn't be able to impersonate as the created service account.
