### PR TITLE
Add a random uuid suffix to workload identity pool ID

### DIFF
--- a/modules/services/cloud-bench/trust_relationship/main.tf
+++ b/modules/services/cloud-bench/trust_relationship/main.tf
@@ -82,7 +82,7 @@ resource "google_iam_workload_identity_pool" "pool" {
   project = var.project_id
 
   provider                  = google-beta
-  workload_identity_pool_id = "sysdigcloud-${random_uuid.pool_id.result}"
+  workload_identity_pool_id = "sysdigcloud-${substr(random_uuid.pool_id.result, -6, -1)}"
 }
 
 resource "google_iam_workload_identity_pool_provider" "pool_provider" {
@@ -90,7 +90,7 @@ resource "google_iam_workload_identity_pool_provider" "pool_provider" {
 
   provider                           = google-beta
   workload_identity_pool_id          = google_iam_workload_identity_pool.pool.workload_identity_pool_id
-  workload_identity_pool_provider_id = "sysdigcloud-${random_uuid.pool_id.result}"
+  workload_identity_pool_provider_id = "sysdigcloud-${substr(random_uuid.pool_id.result, -6, -1)}"
   display_name                       = "Sysdigcloud"
   description                        = "Sysdig Secure for Cloud"
   disabled                           = false

--- a/modules/services/cloud-bench/trust_relationship/main.tf
+++ b/modules/services/cloud-bench/trust_relationship/main.tf
@@ -75,11 +75,14 @@ resource "google_service_account_iam_binding" "sa_pool_binding" {
 # See https://cloud.google.com/iam/docs/access-resources-aws
 ###################################################
 
+resource "random_uuid" "pool_id" {
+}
+
 resource "google_iam_workload_identity_pool" "pool" {
   project = var.project_id
 
   provider                  = google-beta
-  workload_identity_pool_id = "sysdigcloud"
+  workload_identity_pool_id = "sysdigcloud-${random_uuid.pool_id.result}"
 }
 
 resource "google_iam_workload_identity_pool_provider" "pool_provider" {
@@ -87,7 +90,7 @@ resource "google_iam_workload_identity_pool_provider" "pool_provider" {
 
   provider                           = google-beta
   workload_identity_pool_id          = google_iam_workload_identity_pool.pool.workload_identity_pool_id
-  workload_identity_pool_provider_id = "sysdigcloud"
+  workload_identity_pool_provider_id = "sysdigcloud-${random_uuid.pool_id.result}"
   display_name                       = "Sysdigcloud"
   description                        = "Sysdig Secure for Cloud"
   disabled                           = false


### PR DESCRIPTION
We need reproducibility (ability to destroy and recreate) SFC for Google. 


But we are hitting the known problem described in [https://github.com/sysdiglabs/terraform-google-secure-for-cloud#q-getting-error-creating-workloadidentit[…]error-409-requested-entity-already-exists](https://github.com/sysdiglabs/terraform-google-secure-for-cloud#q-getting-error-creating-workloadidentitypool-googleapi-error-409-requested-entity-already-exists), so we need to manually undelete and import the workload identity pool every time.

This adds an uuid suffix to the identity pool ID and provider ID to make sure a new one is created everytime

<!--
check contribution guidelines at https://github.com/sysdiglabs/terraform-google-secure-for-cloud/blob/master/CONTRIBUTE.md#contribution-checklist
-->
