### PR TITLE
refactor: avoid benchmark role collision with var.name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 deps:
 	go install github.com/terraform-docs/terraform-docs@v0.16.0
 	go install github.com/hashicorp/terraform-config-inspect@latest
-	curl -L "`curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip"`" -o tflint.zip && \
+
+# not working- fixme
+#	curl -L "`curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip"`" -o tflint.zip && \
+
+	curl -L https://github.com/terraform-linters/tflint/releases/download/v0.44.1/tflint_linux_amd64.zip -o tflint.zip && \
 		unzip tflint.zip && \
 		rm tflint.zip && \
 		mv tflint "`go env GOPATH`/bin"

--- a/examples/organization/README.md
+++ b/examples/organization/README.md
@@ -143,7 +143,7 @@ module "secure-for-cloud_example_organization" {
 | <a name="input_deploy_benchmark"></a> [deploy\_benchmark](#input\_deploy\_benchmark) | whether benchmark module is to be deployed | `bool` | `true` | no |
 | <a name="input_deploy_scanning"></a> [deploy\_scanning](#input\_deploy\_scanning) | true/false whether scanning module is to be deployed | `bool` | `false` | no |
 | <a name="input_max_instances"></a> [max\_instances](#input\_max\_instances) | Max number of instances for the workloads | `number` | `1` | no |
-| <a name="input_name"></a> [name](#input\_name) | Name to be assigned to all child resources. A suffix may be added internally when required. Use default value unless you need to install multiple instances | `string` | `"sfc"` | no |
+| <a name="input_name"></a> [name](#input\_name) | Suffix to be assigned to all created resources. Modify this value in case of conflict / 409 error to bypass Google soft delete issues | `string` | `"sfc"` | no |
 | <a name="input_repository_project_ids"></a> [repository\_project\_ids](#input\_repository\_project\_ids) | Projects were a `gcr`-named topic will be to subscribe to its repository events. If empty, all organization projects will be defaulted. | `list(string)` | `[]` | no |
 
 ## Outputs

--- a/examples/organization/benchmark.tf
+++ b/examples/organization/benchmark.tf
@@ -1,0 +1,19 @@
+locals {
+  benchmark_projects_ids = length(var.benchmark_project_ids) == 0 ? [for p in data.google_projects.all_projects.projects : p.project_id] : var.benchmark_project_ids
+}
+
+module "cloud_bench" {
+  providers = {
+    google      = google.multiproject
+    google-beta = google-beta.multiproject
+  }
+
+  count  = var.deploy_benchmark ? 1 : 0
+  source = "../../modules/services/cloud-bench"
+
+  is_organizational   = true
+  organization_domain = var.organization_domain
+  role_name           = "${var.name}${var.benchmark_role_name}"
+  regions             = var.benchmark_regions
+  project_ids         = local.benchmark_projects_ids
+}

--- a/examples/organization/main.tf
+++ b/examples/organization/main.tf
@@ -110,28 +110,3 @@ module "pubsub_http_subscription" {
   push_to_cloudrun   = true
   deploy_scanning    = var.deploy_scanning
 }
-
-
-#--------------------
-# benchmark
-#--------------------
-
-locals {
-  benchmark_projects_ids = length(var.benchmark_project_ids) == 0 ? [for p in data.google_projects.all_projects.projects : p.project_id] : var.benchmark_project_ids
-}
-
-module "cloud_bench" {
-  providers = {
-    google      = google.multiproject
-    google-beta = google-beta.multiproject
-  }
-
-  count  = var.deploy_benchmark ? 1 : 0
-  source = "../../modules/services/cloud-bench"
-
-  is_organizational   = true
-  organization_domain = var.organization_domain
-  role_name           = var.benchmark_role_name
-  regions             = var.benchmark_regions
-  project_ids         = local.benchmark_projects_ids
-}

--- a/examples/organization/variables.tf
+++ b/examples/organization/variables.tf
@@ -65,7 +65,7 @@ variable "benchmark_role_name" {
 #
 variable "name" {
   type        = string
-  description = "Name to be assigned to all child resources. A suffix may be added internally when required. Use default value unless you need to install multiple instances"
+  description = "Suffix to be assigned to all created resources. Modify this value in case of conflict / 409 error to bypass Google soft delete issues"
   default     = "sfc"
 
   validation {

--- a/examples/single-project-k8s/README.md
+++ b/examples/single-project-k8s/README.md
@@ -116,7 +116,7 @@ See [inputs summary](#inputs) or module module [`variables.tf`](./variables.tf) 
 | <a name="input_cloud_connector_image"></a> [cloud\_connector\_image](#input\_cloud\_connector\_image) | Cloud-connector image to deploy | `string` | `"quay.io/sysdig/cloud-connector"` | no |
 | <a name="input_deploy_benchmark"></a> [deploy\_benchmark](#input\_deploy\_benchmark) | whether benchmark module is to be deployed | `bool` | `true` | no |
 | <a name="input_deploy_scanning"></a> [deploy\_scanning](#input\_deploy\_scanning) | true/false whether scanning module is to be deployed | `bool` | `false` | no |
-| <a name="input_name"></a> [name](#input\_name) | Name to be assigned to all child resources. A suffix may be added internally when required. Use default value unless you need to install multiple instances | `string` | `"sfc"` | no |
+| <a name="input_name"></a> [name](#input\_name) | Suffix to be assigned to all created resources. Modify this value in case of conflict / 409 error to bypass Google soft delete issues | `string` | `"sfc"` | no |
 
 ## Outputs
 

--- a/examples/single-project-k8s/variables.tf
+++ b/examples/single-project-k8s/variables.tf
@@ -32,7 +32,7 @@ variable "benchmark_role_name" {
 # general
 variable "name" {
   type        = string
-  description = "Name to be assigned to all child resources. A suffix may be added internally when required. Use default value unless you need to install multiple instances"
+  description = "Suffix to be assigned to all created resources. Modify this value in case of conflict / 409 error to bypass Google soft delete issues"
   default     = "sfc"
 
   validation {

--- a/examples/single-project/README.md
+++ b/examples/single-project/README.md
@@ -112,7 +112,7 @@ module "secure-for-cloud_example_single-project" {
 | <a name="input_benchmark_role_name"></a> [benchmark\_role\_name](#input\_benchmark\_role\_name) | The name of the Service Account that will be created. | `string` | `"sysdigcloudbench"` | no |
 | <a name="input_deploy_benchmark"></a> [deploy\_benchmark](#input\_deploy\_benchmark) | whether benchmark module is to be deployed | `bool` | `true` | no |
 | <a name="input_deploy_scanning"></a> [deploy\_scanning](#input\_deploy\_scanning) | true/false whether scanning module is to be deployed | `bool` | `false` | no |
-| <a name="input_name"></a> [name](#input\_name) | Name to be assigned to all child resources. A suffix may be added internally when required. Use default value unless you need to install multiple instances | `string` | `"sfc"` | no |
+| <a name="input_name"></a> [name](#input\_name) | Suffix to be assigned to all created resources. Modify this value in case of conflict / 409 error to bypass Google soft delete issues | `string` | `"sfc"` | no |
 
 ## Outputs
 

--- a/examples/single-project/variables.tf
+++ b/examples/single-project/variables.tf
@@ -37,7 +37,7 @@ variable "benchmark_role_name" {
 #
 variable "name" {
   type        = string
-  description = "Name to be assigned to all child resources. A suffix may be added internally when required. Use default value unless you need to install multiple instances"
+  description = "Suffix to be assigned to all created resources. Modify this value in case of conflict / 409 error to bypass Google soft delete issues"
   default     = "sfc"
 
   validation {

--- a/modules/services/cloud-bench/README.md
+++ b/modules/services/cloud-bench/README.md
@@ -1,3 +1,12 @@
+# Cloud Bench deploy for GCP
+
+Deployed on the **target GCP account(s)**:
+- The required Workload Identity Pool + Provider + Service Account,  to allow Sysdig to run GCP Benchmarks on your behalf.
+
+Deployed on **Sysdig Backend**
+- An `gcp_foundations_bench-1.2.0` benchmark task schedule on a random hour of the day `rand rand * * *`
+- coped to the configured `gcp.projectId` and `gcp.region`
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/modules/services/cloud-bench/variables.tf
+++ b/modules/services/cloud-bench/variables.tf
@@ -6,7 +6,7 @@ variable "regions" {
 
 variable "role_name" {
   type        = string
-  description = "The name of the Service Account that will be created."
+  description = "The name of the Service Account/Role that will be created. Modify this value in case of conflict / 409 error to bypass Google soft delete"
   default     = "sysdigcloudbench"
 }
 


### PR DESCRIPTION
during a customer escalation we saw that both role and service account conflict due to GCP softdelete  + previously existing resource

for single account it was already done, but organizational example lacked the `var.name` prefix insertion on both items.
this PR adds both from the example layer.

**side-quest**
- added a readme for benchmark since it was empty
- clarified bit more `var.name` usage on all examples

<!--
check contribution guidelines at https://github.com/sysdiglabs/terraform-google-secure-for-cloud/blob/master/CONTRIBUTE.md#contribution-checklist
-->
