### PR TITLE
refactor(bench): Refactor Org WIF module to simplify variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ $ terraform import 'module.secure-for-cloud_example_single-project.module.cloud_
 $ terraform import 'module.secure-for-cloud_example_organization.module.cloud_bench[0].module.trust_relationship["<PROJECT_ID>"].google_iam_workload_identity_pool.pool' <PROJECT_ID>/sysdigcloud
 $ terraform import 'module.secure-for-cloud_example_organization.module.cloud_bench[0].module.trust_relationship["<PROJECT_ID>"].google_iam_workload_identity_pool_provider.pool_provider' <PROJECT_ID>/sysdigcloud/sysdigcloud
  ```
- 
+
  The import resource to use, is the one pointed out in your terraform plan/apply error messsage
  ```
  -- for
@@ -215,13 +215,13 @@ Error: Error creating WorkloadIdentityPool: googleapi: Error 409: Requested enti
   with module.secure-for-cloud_example_organization.module.cloud_bench[0].module.trust_relationship["org-child-project-1"].google_iam_workload_identity_pool.pool,
   on .... in resource "google_iam_workload_identity_pool" "pool":
   resource "google_iam_workload_identity_pool" "pool" {
-  
+
  -- use
  ' module.secure-for-cloud_example_organization.module.cloud_bench[0].module.trust_relationship["org-child-project-1"].google_iam_workload_identity_pool.pool' as your import resource
- 
+
  -- such as
  $ terraform import 'module.secure-for-cloud_example_organization.module.cloud_bench[0].module.trust_relationship["org-child-project-1"].google_iam_workload_identity_pool.pool' 'org-child-project-1/sysdigcloud'
- 
+
  ```
 
  Note: if you're using terragrunt, run `terragrunt import`

--- a/examples/organization-org_compliance/main.tf
+++ b/examples/organization-org_compliance/main.tf
@@ -115,12 +115,6 @@ module "pubsub_http_subscription" {
 #--------------------
 # benchmark
 #--------------------
-
-locals {
-  benchmark_projects_ids   = length(var.benchmark_project_ids) == 0 ? [for p in data.google_projects.all_projects.projects : p.project_id] : var.benchmark_project_ids
-  project_id_to_number_map = { for p in data.google_projects.all_projects.projects : p.project_id => p.number }
-}
-
 module "cloud_bench_workload_identity" {
   providers = {
     google      = google.multiproject
@@ -130,11 +124,9 @@ module "cloud_bench_workload_identity" {
   count  = var.deploy_benchmark ? 1 : 0
   source = "../../modules/services/cloud-bench-workload-identity"
 
-  is_organizational     = true
   organization_domain   = var.organization_domain
   role_name             = var.benchmark_role_name
   regions               = var.benchmark_regions
-  project_ids           = local.benchmark_projects_ids
+  project_ids           = var.benchmark_project_ids
   project_id            = data.google_client_config.current.project
-  project_id_number_map = local.project_id_to_number_map
 }

--- a/examples/organization-org_compliance/main.tf
+++ b/examples/organization-org_compliance/main.tf
@@ -124,9 +124,9 @@ module "cloud_bench_workload_identity" {
   count  = var.deploy_benchmark ? 1 : 0
   source = "../../modules/services/cloud-bench-workload-identity"
 
-  organization_domain   = var.organization_domain
-  role_name             = var.benchmark_role_name
-  regions               = var.benchmark_regions
-  project_ids           = var.benchmark_project_ids
-  project_id            = data.google_client_config.current.project
+  organization_domain = var.organization_domain
+  role_name           = var.benchmark_role_name
+  regions             = var.benchmark_regions
+  project_ids         = var.benchmark_project_ids
+  project_id          = data.google_client_config.current.project
 }

--- a/modules/services/cloud-bench-workload-identity/main.tf
+++ b/modules/services/cloud-bench-workload-identity/main.tf
@@ -1,14 +1,26 @@
+data "google_organization" "org" {
+  domain = var.organization_domain
+}
+
+data "google_projects" "all_projects" {
+  filter = "parent.id:${data.google_organization.org.org_id} parent.type:organization lifecycleState:ACTIVE"
+}
+
 locals {
-  project_ids = var.is_organizational ? var.project_ids : [var.project_id]
+  # If specific projects are specified, use that list. Otherwise, use all active projects in the org
+  project_ids = length(var.project_ids) == 0 ? [for p in data.google_projects.all_projects.projects : p.project_id] : var.project_ids
+
+  # Fetch both the project ID and project number (Needed by Workload Identity Federation)
+  project_id_to_number_map = { for p in data.google_projects.all_projects.projects : p.project_id => p.number }
 }
 
 module "trust_relationship" {
   source                = "./trust_relationship"
   role_name             = var.role_name
-  project_ids           = local.project_ids
   organization_domain   = var.organization_domain
   project_id            = var.project_id
-  project_id_number_map = var.project_id_number_map
+  project_ids           = local.project_ids
+  project_id_number_map = local.project_id_to_number_map
 }
 
 module "task" {
@@ -16,7 +28,7 @@ module "task" {
   project_id          = var.project_id
   project_ids         = local.project_ids
   regions             = var.regions
-  is_organizational   = var.is_organizational
+  is_organizational   = true
   organization_domain = var.organization_domain
 
   depends_on = [module.trust_relationship]

--- a/modules/services/cloud-bench-workload-identity/variables.tf
+++ b/modules/services/cloud-bench-workload-identity/variables.tf
@@ -10,34 +10,18 @@ variable "role_name" {
   default     = "sysdigcloudbench"
 }
 
-#For single project
 variable "project_id" {
   type        = string
-  description = "Google cloud project ID to run Benchmarks on. It will create a trust-relationship, to allow Sysdig usage."
-  default     = ""
+  description = "Google cloud project ID in which Workload Identity Federation resources will be provisioned."
 }
 
-# For organizational
 variable "project_ids" {
   type        = list(string)
-  description = "Google cloud project IDs to run Benchmarks on. It will create a trust-relationship on each, to allow Sysdig usage. If empty, all organization projects will be defaulted."
+  description = "Google cloud project IDs to onboard. If empty, all projects within the organization will be onboarded."
   default     = []
-}
-
-variable "project_id_number_map" {
-  type        = map(string)
-  description = "GCP project id to project number map"
-  default     = {}
-}
-
-variable "is_organizational" {
-  type        = bool
-  description = "Whether this task is being created at the org or project level"
-  default     = false
 }
 
 variable "organization_domain" {
   type        = string
   description = "Organization domain. e.g. sysdig.com"
-  default     = ""
 }


### PR DESCRIPTION
Certain variables used in the example main.tf were only used in one place in a single submodule. This PR moves those variables/locals closer to where they are used, to simplify the variables needed when using the module. 

This also allows the module to be used as a standalone building block.

Manually verified by onboarding a GCP org and running a benchmark