### PR TITLE
feat: provide secure api token via secret manager in cloud run

### DIFF
--- a/examples/organization-org_compliance/main.tf
+++ b/examples/organization-org_compliance/main.tf
@@ -1,9 +1,11 @@
 locals {
-  verify_ssl             = length(regexall("^https://.*?\\.sysdig.com/?", data.sysdig_secure_connection.current.secure_url)) != 0
-  connector_filter       = <<EOT
+  verify_ssl       = length(regexall("^https://.*?\\.sysdig.com/?", data.sysdig_secure_connection.current.secure_url)) != 0
+  connector_filter = <<EOT
   logName=~"/logs/cloudaudit.googleapis.com%2Factivity$" AND -resource.type="k8s_cluster"
 EOT
-  repository_project_ids = var.deploy_scanning ? length(var.repository_project_ids) == 0 ? [for p in data.google_projects.all_projects.projects : p.project_id] : var.repository_project_ids : []
+  repository_project_ids = var.deploy_scanning ? length(var.repository_project_ids) == 0 ? [
+    for p in data.google_projects.all_projects.projects : p.project_id
+  ] : var.repository_project_ids : []
 }
 
 data "google_organization" "org" {
@@ -67,13 +69,13 @@ module "secure_secrets" {
 module "cloud_connector" {
   source = "../../modules/services/cloud-connector"
 
-  cloud_connector_sa_email   = google_service_account.connector_sa.email
-  sysdig_secure_endpoint     = data.sysdig_secure_connection.current.secure_url
-  sysdig_secure_api_token    = data.sysdig_secure_connection.current.secure_api_token
-  connector_pubsub_topic_id  = module.connector_organization_sink.pubsub_topic_id
-  secure_api_token_secret_id = module.secure_secrets.secure_api_token_secret_name
-  max_instances              = var.max_instances
-  project_id                 = data.google_client_config.current.project
+  cloud_connector_sa_email          = google_service_account.connector_sa.email
+  sysdig_secure_endpoint            = data.sysdig_secure_connection.current.secure_url
+  sysdig_secure_api_token_secret_id = module.secure_secrets.secure_api_token_secret_name
+  connector_pubsub_topic_id         = module.connector_organization_sink.pubsub_topic_id
+  secure_api_token_secret_id        = module.secure_secrets.secure_api_token_secret_name
+  max_instances                     = var.max_instances
+  project_id                        = data.google_client_config.current.project
 
   #defaults
   name              = "${var.name}-cloudconnector"

--- a/examples/organization/main.tf
+++ b/examples/organization/main.tf
@@ -1,9 +1,11 @@
 locals {
-  verify_ssl             = length(regexall("^https://.*?\\.sysdig.com/?", data.sysdig_secure_connection.current.secure_url)) != 0
-  connector_filter       = <<EOT
+  verify_ssl       = length(regexall("^https://.*?\\.sysdig.com/?", data.sysdig_secure_connection.current.secure_url)) != 0
+  connector_filter = <<EOT
   logName=~"/logs/cloudaudit.googleapis.com%2Factivity$" AND -resource.type="k8s_cluster"
 EOT
-  repository_project_ids = var.deploy_scanning ? length(var.repository_project_ids) == 0 ? [for p in data.google_projects.all_projects.projects : p.project_id] : var.repository_project_ids : []
+  repository_project_ids = var.deploy_scanning ? length(var.repository_project_ids) == 0 ? [
+    for p in data.google_projects.all_projects.projects : p.project_id
+  ] : var.repository_project_ids : []
 }
 
 data "google_organization" "org" {
@@ -67,13 +69,13 @@ module "secure_secrets" {
 module "cloud_connector" {
   source = "../../modules/services/cloud-connector"
 
-  cloud_connector_sa_email   = google_service_account.connector_sa.email
-  sysdig_secure_endpoint     = data.sysdig_secure_connection.current.secure_url
-  sysdig_secure_api_token    = data.sysdig_secure_connection.current.secure_api_token
-  connector_pubsub_topic_id  = module.connector_organization_sink.pubsub_topic_id
-  secure_api_token_secret_id = module.secure_secrets.secure_api_token_secret_name
-  max_instances              = var.max_instances
-  project_id                 = data.google_client_config.current.project
+  cloud_connector_sa_email          = google_service_account.connector_sa.email
+  sysdig_secure_endpoint            = data.sysdig_secure_connection.current.secure_url
+  sysdig_secure_api_token_secret_id = module.secure_secrets.secure_api_token_secret_name
+  connector_pubsub_topic_id         = module.connector_organization_sink.pubsub_topic_id
+  secure_api_token_secret_id        = module.secure_secrets.secure_api_token_secret_name
+  max_instances                     = var.max_instances
+  project_id                        = data.google_client_config.current.project
 
   #defaults
   name              = "${var.name}-cloudconnector"

--- a/examples/single-project/main.tf
+++ b/examples/single-project/main.tf
@@ -32,9 +32,9 @@ module "cloud_connector" {
   source = "../../modules/services/cloud-connector"
   name   = "${var.name}-cloudconnector"
 
-  sysdig_secure_endpoint  = data.sysdig_secure_connection.current.secure_url
-  sysdig_secure_api_token = data.sysdig_secure_connection.current.secure_api_token
-  verify_ssl              = local.verify_ssl
+  sysdig_secure_endpoint            = data.sysdig_secure_connection.current.secure_url
+  sysdig_secure_api_token_secret_id = module.secure_secrets.secure_api_token_secret_name
+  verify_ssl                        = local.verify_ssl
 
   project_id                 = data.google_client_config.current.project
   cloud_connector_sa_email   = google_service_account.connector_sa.email

--- a/modules/services/cloud-connector/README.md
+++ b/modules/services/cloud-connector/README.md
@@ -59,7 +59,6 @@ No modules.
 | <a name="input_connector_pubsub_topic_id"></a> [connector\_pubsub\_topic\_id](#input\_connector\_pubsub\_topic\_id) | Cloud Connector PubSub single account topic id | `string` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | organizational member project ID where the secure-for-cloud workload is going to be deployed | `string` | n/a | yes |
 | <a name="input_secure_api_token_secret_id"></a> [secure\_api\_token\_secret\_id](#input\_secure\_api\_token\_secret\_id) | Sysdig Secure API token secret id | `string` | n/a | yes |
-| <a name="input_sysdig_secure_api_token"></a> [sysdig\_secure\_api\_token](#input\_sysdig\_secure\_api\_token) | Sysdig's Secure API Token | `string` | n/a | yes |
 | <a name="input_sysdig_secure_endpoint"></a> [sysdig\_secure\_endpoint](#input\_sysdig\_secure\_endpoint) | Sysdig's Secure API URL | `string` | n/a | yes |
 | <a name="input_cpu"></a> [cpu](#input\_cpu) | Amount of CPU to reserve for cloud-connector cloud run service | `string` | `"1"` | no |
 | <a name="input_deploy_scanning"></a> [deploy\_scanning](#input\_deploy\_scanning) | true/false whether scanning module is to be deployed | `bool` | `false` | no |
@@ -69,6 +68,8 @@ No modules.
 | <a name="input_max_instances"></a> [max\_instances](#input\_max\_instances) | Max number of instances for the Cloud Connector | `number` | `1` | no |
 | <a name="input_memory"></a> [memory](#input\_memory) | Amount of memory to reserve for cloud-connector cloud run service | `string` | `"500Mi"` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name to be assigned to all child resources. A suffix may be added internally when required. Use default value unless you need to install multiple instances | `string` | `"sfc-cloudconnector"` | no |
+| <a name="input_sysdig_secure_api_token"></a> [sysdig\_secure\_api\_token](#input\_sysdig\_secure\_api\_token) | Sysdig's Secure API Token. Deprecated, use sysdig\_secure\_api\_token\_secret\_id instead, with a secret manager secret. | `string` | `""` | no |
+| <a name="input_sysdig_secure_api_token_secret_id"></a> [sysdig\_secure\_api\_token\_secret\_id](#input\_sysdig\_secure\_api\_token\_secret\_id) | Sysdig's Secure API Token secret id | `string` | `""` | no |
 | <a name="input_verify_ssl"></a> [verify\_ssl](#input\_verify\_ssl) | Verify the SSL certificate of the Secure endpoint | `bool` | `true` | no |
 
 ## Outputs

--- a/modules/services/cloud-connector/main.tf
+++ b/modules/services/cloud-connector/main.tf
@@ -78,11 +78,29 @@ resource "google_cloud_run_service" "cloud_connector" {
           container_port = 5000
         }
 
-        env {
-          #TODO: Put secrets in secretsmanager?
-          name  = "SECURE_API_TOKEN"
-          value = var.sysdig_secure_api_token
+        dynamic "env" {
+          for_each = var.sysdig_secure_api_token == "" ? [] : [1]
+
+          content {
+            name  = "SECURE_API_TOKEN"
+            value = var.sysdig_secure_api_token
+          }
         }
+
+        dynamic "env" {
+          for_each = var.sysdig_secure_api_token_secret_id == "" ? [] : [1]
+
+          content {
+            name = "SECURE_API_TOKEN"
+            value_from {
+              secret_key_ref {
+                name = var.sysdig_secure_api_token_secret_id
+                key  = "latest"
+              }
+            }
+          }
+        }
+
 
         dynamic "env" {
           for_each = toset(local.task_env_vars)

--- a/modules/services/cloud-connector/variables.tf
+++ b/modules/services/cloud-connector/variables.tf
@@ -6,8 +6,15 @@ variable "cloud_connector_sa_email" {
 
 variable "sysdig_secure_api_token" {
   type        = string
-  description = "Sysdig's Secure API Token"
+  description = "Sysdig's Secure API Token. Deprecated, use sysdig_secure_api_token_secret_id instead, with a secret manager secret."
+  default     = ""
   sensitive   = true
+}
+
+variable "sysdig_secure_api_token_secret_id" {
+  type        = string
+  description = "Sysdig's Secure API Token secret id"
+  default     = ""
 }
 
 variable "sysdig_secure_endpoint" {


### PR DESCRIPTION
Modifies the deployment of the cloud-connector to accept the secret ID of the Secure API Token so it can be used instead of plain-text env var.