### PR TITLE
fix: Make WIF pool datasource conditional on reuse

### DIFF
--- a/modules/services/cloud-bench/trust_relationship/main.tf
+++ b/modules/services/cloud-bench/trust_relationship/main.tf
@@ -79,6 +79,7 @@ resource "google_service_account_iam_binding" "sa_pool_binding" {
 
 
 data "google_iam_workload_identity_pool" "pool" {
+  count   = var.reuse_workload_identity_pool ? 1 : 0
   project = var.project_id
 
   provider                  = google-beta


### PR DESCRIPTION
Make the WIF pool datasource conditional, based on `var.reuse_workload_identity_pool`. 

For fresh installs, attempting to load this datasource fails, and it is always loaded.