### PR TITLE
chore: remove max terraform version limit

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Install Terraform v${{ steps.minMax.outputs.minVersion }}
         uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 1.5 # ${{ steps.minMax.outputs.minVersion }}
+          terraform_version: ${{ steps.minMax.outputs.minVersion }}
       - name: Install pre-commit dependencies
         run: |
           pip install pre-commit
@@ -109,7 +109,7 @@ jobs:
       - name: Install Terraform v${{ matrix.version }}
         uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 1.5 #${{ matrix.version }}
+          terraform_version: ${{ matrix.version }}
       - name: Install pre-commit dependencies
         run: |
           pip install pre-commit

--- a/examples/organization-org_compliance/README.md
+++ b/examples/organization-org_compliance/README.md
@@ -111,7 +111,7 @@ module "secure-for-cloud_example_organization" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.0, < 1.6.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.21.0, < 5.0.0 |
 | <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 4.21.0, < 5.0.0 |
 | <a name="requirement_sysdig"></a> [sysdig](#requirement\_sysdig) | >= 0.5.46 |

--- a/examples/organization-org_compliance/versions.tf
+++ b/examples/organization-org_compliance/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.15.0, < 1.6.0"
+  required_version = ">= 0.15.0"
 
   required_providers {
     google = {

--- a/examples/organization/README.md
+++ b/examples/organization/README.md
@@ -100,7 +100,7 @@ module "secure-for-cloud_example_organization" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.0, < 1.6.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.21.0, < 5.0.0 |
 | <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 4.21.0, < 5.0.0 |
 | <a name="requirement_sysdig"></a> [sysdig](#requirement\_sysdig) | >= 0.5.21 |

--- a/examples/organization/versions.tf
+++ b/examples/organization/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.15.0, < 1.6.0"
+  required_version = ">= 0.15.0"
 
   required_providers {
     google = {

--- a/examples/single-project-k8s/README.md
+++ b/examples/single-project-k8s/README.md
@@ -71,7 +71,7 @@ See [inputs summary](#inputs) or module module [`variables.tf`](./variables.tf) 
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.0, < 1.6.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.21.0, < 5.0.0 |
 | <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 4.21.0, < 5.0.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >=2.3.0 |

--- a/examples/single-project-k8s/versions.tf
+++ b/examples/single-project-k8s/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.15.0, < 1.6.0"
+  required_version = ">= 0.15.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/examples/single-project/README.md
+++ b/examples/single-project/README.md
@@ -73,7 +73,7 @@ module "secure-for-cloud_example_single-project" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.0, < 1.6.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.21.0, < 5.0.0 |
 | <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 4.21.0, < 5.0.0 |
 | <a name="requirement_sysdig"></a> [sysdig](#requirement\_sysdig) | >= 0.5.21 |

--- a/examples/single-project/versions.tf
+++ b/examples/single-project/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.15.0, < 1.6.0"
+  required_version = ">= 0.15.0"
 
   required_providers {
     google = {

--- a/modules/services/cloud-bench-workload-identity/versions.tf
+++ b/modules/services/cloud-bench-workload-identity/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.15.0, < 1.6.0"
+  required_version = ">= 0.15.0"
 
   required_providers {
     google = {

--- a/modules/services/cloud-bench/README.md
+++ b/modules/services/cloud-bench/README.md
@@ -15,7 +15,7 @@ Deployed on **Sysdig Backend**
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.0, < 1.6.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.21.0, < 5.0.0 |
 | <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 4.21.0, < 5.0.0 |
 | <a name="requirement_sysdig"></a> [sysdig](#requirement\_sysdig) | >= 0.5.21 |

--- a/modules/services/cloud-bench/versions.tf
+++ b/modules/services/cloud-bench/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.15.0, < 1.6.0"
+  required_version = ">= 0.15.0"
 
   required_providers {
     google = {

--- a/modules/services/cloud-connector/README.md
+++ b/modules/services/cloud-connector/README.md
@@ -24,7 +24,7 @@ module "cloud_connector_gcp" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.0, < 1.6.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.21.0, < 5.0.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.1.0 |
 

--- a/modules/services/cloud-connector/main.tf
+++ b/modules/services/cloud-connector/main.tf
@@ -79,7 +79,7 @@ resource "google_cloud_run_service" "cloud_connector" {
         }
 
         dynamic "env" {
-          for_each = var.sysdig_secure_api_token == "" ? toset([]) : toset([1])
+          for_each = nonsensitive(var.sysdig_secure_api_token) == "" ? [] : [1]
 
           content {
             name  = "SECURE_API_TOKEN"

--- a/modules/services/cloud-connector/versions.tf
+++ b/modules/services/cloud-connector/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.15.0, < 1.6.0"
+  required_version = ">= 0.15.0"
 
   required_providers {
     google = {


### PR DESCRIPTION
Removes the max terraform version so newer versions can still use this module.