### PR TITLE
Cloud connector deprecation

### DIFF
--- a/.github/workflows/ci-integration-test.yaml
+++ b/.github/workflows/ci-integration-test.yaml
@@ -26,6 +26,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_wrapper: false
+
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ deps:
 		unzip tflint.zip && \
 		rm tflint.zip && \
 		mv tflint "`go env GOPATH`/bin"
-	curl -L https://github.com/tenable/terrascan/releases/download/v1.9.0/terrascan_1.9.0_Linux_x86_64.tar.gz -o terrascan.tar.gz && \
+	curl -L https://github.com/tenable/terrascan/releases/download/v1.19.9/terrascan_1.19.9_Linux_x86_64.tar.gz -o terrascan.tar.gz && \
 		tar -xf terrascan.tar.gz terrascan && \
 		rm terrascan.tar.gz && \
 		install terrascan "`go env GOPATH`/bin" && \

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # Sunset Notice
 
 > [!CAUTION]
-> Sysdig released a new onboarding experience for GCP in November 2024. We recommend connecting your cloud accounts by [following these instructions](https://docs.sysdig.com/en/docs/sysdig-secure/connect-cloud-accounts/).
+> Sysdig released a new onboarding experience for GCP in November 2024. Follow [these instructions](https://docs.sysdig.com/en/docs/sysdig-secure/connect-cloud-accounts/) to connect your cloud environment.
 >
-> This repository should be used solely in cases where Agentless Threat Detection cannot be used.
 
 ## Usage
 

--- a/examples/single-project-k8s/README.md
+++ b/examples/single-project-k8s/README.md
@@ -68,7 +68,7 @@ See [inputs summary](#inputs) or module module [`variables.tf`](./variables.tf) 
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.21.0, < 5.0.0 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >=2.3.0 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >=2.3.0, <3.0.0 |
 | <a name="requirement_sysdig"></a> [sysdig](#requirement\_sysdig) | >= 0.5.21 |
 
 ## Providers
@@ -76,7 +76,7 @@ See [inputs summary](#inputs) or module module [`variables.tf`](./variables.tf) 
 | Name | Version |
 |------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | >= 4.21.0, < 5.0.0 |
-| <a name="provider_helm"></a> [helm](#provider\_helm) | >=2.3.0 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | >=2.3.0, <3.0.0 |
 | <a name="provider_sysdig"></a> [sysdig](#provider\_sysdig) | >= 0.5.21 |
 
 ## Modules

--- a/examples/single-project-k8s/versions.tf
+++ b/examples/single-project-k8s/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">=2.3.0"
+      version = ">=2.3.0, <3.0.0"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Deprecate cloud connector by updating README.md
- Fix CI: pin Helm provider to `<3.0.0` to avoid breaking changes in 3.x (`set`/`set_sensitive` block syntax removed)
- Fix CI: upgrade terrascan from v1.9.0 to v1.19.9 to resolve OPA `regex.match` incompatibility

This replaces #156 (from fork), which could not access repo secrets needed for integration tests.

## Test plan

- [ ] `Min TF validate` jobs pass with pinned Helm provider constraint
- [ ] `Max TF pre-commit` jobs pass with updated terrascan